### PR TITLE
Bugfix for `interp_bedmachine_antarctica` (python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ conda env create -f environment.yml
 $ conda activate interp_bedmachine
 ```
 
-#### Example usage:
+#### Example usage (Python):
 
 ```
 $ python
@@ -97,4 +97,20 @@ array([[-4442.84863281, -4442.40963504, -4441.97063731, ...,
           264.8464815 ,   262.60142472,   260.35621881],
        [-4018.03344727, -4019.59069298, -4021.14789963, ...,
           287.89288765,   284.17862334,   280.46411133]])
+```
+
+#### Example usage (MATLAB):
+
+```
+% Input lat. and lon. and they can be an array or a list.
+lat = [-84.72, -82.03; -83.96, -79.07];
+lon = [92.41 ,85.11; 65.65, 77.67];
+
+% For each lat., lon. calculate the stereographic coordinates
+[x,y] = ll2xy(lat, lon, -1);
+
+% Interpolate the Bedmachine values onto the coordinates
+bed = interpBedmachineAntarctica(x,y,'bed');
+
+disp(bed)
 ```

--- a/example_interpolation.py
+++ b/example_interpolation.py
@@ -1,0 +1,29 @@
+# TODO: turn the python code into an importable package.
+from ll2xy import ll2xy
+from interp_bedmachine_antarctica import interp_bedmachine_antarctica
+
+BEDMACHINE_NC_PATH = './BedMachineAntarctica_2019-11-05_v01.nc'
+VARIABLE = 'bed'
+
+
+lats = [-84.72, -82.03, -83.96, -79.07]
+lons = [92.41, 85.11, 65.65, 77.67]
+
+to_x = []
+to_y = []
+
+for lat, lon in zip(l1, l2):
+    x, y = ll2xy(lat, lon, -1)
+    to_y.append(y)
+    to_x.append(x)
+
+
+interpolated = interp_bedmachine_antarctica(
+    to_x,
+    to_y,
+    VARIABLE,
+    return_grid=False,
+    bedmachine_nc_path=BEDMACHINE_NC_PATH
+)
+
+print(interpolated)

--- a/example_interpolation.py
+++ b/example_interpolation.py
@@ -5,10 +5,10 @@ from interp_bedmachine_antarctica import interp_bedmachine_antarctica
 BEDMACHINE_NC_PATH = './BedMachineAntarctica_2019-11-05_v01.nc'
 VARIABLE = 'bed'
 
-# Set to `True` to get a grid of values instead of just the points represented
-# by `to_x` and `to_y`
+# Set `RETURN_AS_GRID` to `True` to get a grid of values instead of just the points represented
+# by `to_x` and `to_y`. Set to `False` if you just want the output interpolated
+# variable for the points represented by `to_x` and `to_y`.
 RETURN_AS_GRID = False
-
 
 lats = [-84.72, -82.03, -83.96, -79.07]
 lons = [92.41, 85.11, 65.65, 77.67]

--- a/example_interpolation.py
+++ b/example_interpolation.py
@@ -21,7 +21,6 @@ for lat, lon in zip(lats, lons):
     to_y.append(y)
     to_x.append(x)
 
-
 interpolated = interp_bedmachine_antarctica(
     to_x,
     to_y,

--- a/example_interpolation.py
+++ b/example_interpolation.py
@@ -12,7 +12,7 @@ lons = [92.41, 85.11, 65.65, 77.67]
 to_x = []
 to_y = []
 
-for lat, lon in zip(l1, l2):
+for lat, lon in zip(lats, lons):
     x, y = ll2xy(lat, lon, -1)
     to_y.append(y)
     to_x.append(x)

--- a/example_interpolation.py
+++ b/example_interpolation.py
@@ -5,6 +5,10 @@ from interp_bedmachine_antarctica import interp_bedmachine_antarctica
 BEDMACHINE_NC_PATH = './BedMachineAntarctica_2019-11-05_v01.nc'
 VARIABLE = 'bed'
 
+# Set to `True` to get a grid of values instead of just the points represented
+# by `to_x` and `to_y`
+RETURN_AS_GRID = False
+
 
 lats = [-84.72, -82.03, -83.96, -79.07]
 lons = [92.41, 85.11, 65.65, 77.67]
@@ -22,7 +26,7 @@ interpolated = interp_bedmachine_antarctica(
     to_x,
     to_y,
     VARIABLE,
-    return_grid=False,
+    return_grid=RETURN_AS_GRID,
     bedmachine_nc_path=BEDMACHINE_NC_PATH
 )
 

--- a/interp_bedmachine_antarctica.py
+++ b/interp_bedmachine_antarctica.py
@@ -55,6 +55,15 @@ def _interpolate_with_xarray(to_x, to_y, variable, bedmachine_nc_path, *, return
         method = 'linear'
 
     if not return_grid:
+        # if `return_grid` is False, `to_x` and `to_y` should be the same
+        # length (each pair of values represents a point). Ultimately, we should
+        # probably change this interface to make it clearer what the input args
+        # represent.
+        if len(to_x) != len(to_y):
+            raise RuntimeError(
+                'When `return_grid` is False, `to_x` and `to_y` must be arrays of the same length.'
+            )
+
         # https://xarray.pydata.org/en/stable/indexing.html#more-advanced-indexing
         to_x = xr.DataArray(to_x, dims='z')
         to_y = xr.DataArray(to_y, dims='z')

--- a/interp_bedmachine_antarctica.py
+++ b/interp_bedmachine_antarctica.py
@@ -14,15 +14,20 @@ _POSSIBLE_VARIABLES = (
 )
 
 
-def _interpolate_with_xarray(to_x, to_y, variable, bedmachine_nc_path):
+def _interpolate_with_xarray(to_x, to_y, variable, bedmachine_nc_path, *, return_grid):
     """Interpolate `variable` onto `to_x`, `to_y` coordinates using xarray.
 
     xarray's `interp` method should roughly correspond to MATLAB's `interp2`.
     
     Args:
-        to_x: 1D numpy array representing x coordinates to interpolate `variable` onto
-        to_y: 1D numpy array representing y coordinates to interpolate `variable` onto
-        variable: string representing variable to interpolate
+        * to_x: 1D numpy array representing x coordinates to interpolate `variable` onto
+        * to_y: 1D numpy array representing y coordinates to interpolate `variable` onto
+        * variable: string representing variable to interpolate
+        * return_grid (Bool): if True, return a grid of interpolated points of
+          size `to_x` by `to_y`. E.g., if to_x is an array of length 2 and to_y
+          is an array of length 3, a grid of size 2x3 will will be
+          returned. Otherwies, only the coodinate pairs represented by `to_x`
+          and `to_y` will be returned (the diagonal of the grid).
     
     Returns:
         a 2D numpy array of interpolated values.
@@ -49,13 +54,26 @@ def _interpolate_with_xarray(to_x, to_y, variable, bedmachine_nc_path):
         # method=bilinear
         method = 'linear'
 
-    result = xr_variable.interp(coords={'x': to_x, 'y': to_y}, method=method)
+    if not return_grid:
+        # https://xarray.pydata.org/en/stable/indexing.html#more-advanced-indexing
+        to_x = xr.DataArray(to_x, dims='z')
+        to_y = xr.DataArray(to_y, dims='z')
+
+    result = xr_variable.interp(
+        coords={
+            'x': to_x,
+            'y': to_y
+        },
+        method=method
+    )
+
+    breakpoint()
 
     # Return a numpy array to be consistent with the other python scripts.
     return result.values
 
 
-def interp_bedmachine_antarctica(to_x, to_y, variable, *, bedmachine_nc_path):
+def interp_bedmachine_antarctica(to_x, to_y, variable, return_grid=False, *, bedmachine_nc_path):
     """Interpolate `variable` onto `to_x`, `to_y` coordinates.
 
     NOTE:
@@ -66,9 +84,15 @@ def interp_bedmachine_antarctica(to_x, to_y, variable, *, bedmachine_nc_path):
         interpolation algorithm that has not yet been implemented in Python.
 
     Args:
-        to_x: 1D numpy array representing x coordinates to interpolate `variable` onto
-        to_y: 1D numpy array representing y coordinates to interpolate `variable` onto
-        variable: string representing variable to interpolate
+        * to_x: 1D numpy array representing x coordinates to interpolate `variable` onto
+        * to_y: 1D numpy array representing y coordinates to interpolate `variable` onto
+        * variable: string representing variable to interpolate
+        * return_grid (Bool): if True, return a grid of interpolated points of
+          size `to_x` by `to_y`. E.g., if to_x is an array of length 2 and to_y
+          is an array of length 3, a grid of size 2x3 will will be
+          returned. Otherwies, only the coodinate pairs represented by `to_x`
+          and `to_y` will be returned (the diagonal of the grid).
+        * bedmachine_nc_path (required kwarg):
 
     Returns:
         a 2D numpy array of interpolated values.
@@ -78,7 +102,13 @@ def interp_bedmachine_antarctica(to_x, to_y, variable, *, bedmachine_nc_path):
             f'Unexpected variable name {variable}. Must be one of {possible_variables}'
         )
 
-    return _interpolate_with_xarray(to_x, to_y, variable, bedmachine_nc_path)
+    return _interpolate_with_xarray(
+        to_x,
+        to_y,
+        variable,
+        bedmachine_nc_path,
+        return_grid=return_grid
+    )
 
 
 if __name__ == '__main__':

--- a/interp_bedmachine_antarctica.py
+++ b/interp_bedmachine_antarctica.py
@@ -67,8 +67,6 @@ def _interpolate_with_xarray(to_x, to_y, variable, bedmachine_nc_path, *, return
         method=method
     )
 
-    breakpoint()
-
     # Return a numpy array to be consistent with the other python scripts.
     return result.values
 


### PR DESCRIPTION
Make default behavior consistent with MATLAB script. Before this change, a grid
was returned instead of the points represented by the to_x, to_y arrays.